### PR TITLE
Update bcrypt version from 5.0.0->5.0.1 due to node-pre-gyp dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     }
   },
   "dependencies": {
-    "bcrypt": "5.0.0",
+    "bcrypt": "5.0.1",
     "cookie-parser": "1.4.5",
     "dotenv": "8.2.0",
     "email-validator": "2.0.4",


### PR DESCRIPTION
Hello my friends

Bulk version update bcrypt 5.0.0 ->5.0.1, due to no release on bcrypt 5.0.0 for arm64 darwin